### PR TITLE
Updated bower.json to bower install error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.2.0",
-    "backbone.bootstrap-modal": "git@github.com:badgeek/backbone.bootstrap-modal.git#v0.9.0b",
+    "backbone.bootstrap-modal": "https://github.com/badgeek/backbone.bootstrap-modal.git#v0.9.0b",
     "backbone.modal" : "https://github.com/awkward/backbone.modal.git#v1.0.0",
     "backbone.syphon" : "https://github.com/marionettejs/backbone.syphon.git#v0.5.0",
     "marionette": "~2.2.1",


### PR DESCRIPTION
Fixed: ECMDERR Failed to execute "git ls-remote --tags --heads git@github.com:badgeek/backbone.bootstrap-modal.git", exit code of #128 Permission denied (publickey). fatal: Could not read from remote repository.  Please make sure you have the correct access rights and the repository exists.

When running bower install
